### PR TITLE
Introduce a group to hide setup from logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - name: Run payload
+      shell: bash
+      run: |
         if [ "${{ inputs.run_local_checkout }}" == "true" ]; then
           echo "WARNING running local checkout of the action !"
           .  setup-lcg-view.sh local

--- a/run-coverity.sh
+++ b/run-coverity.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+echo "::group::Launching container"
 echo "Checking if there is a working CVMFS mount"
 
 if [ ! -d "/cvmfs/sft.cern.ch/lcg/" ]; then
@@ -86,6 +87,8 @@ tar czvf /myproject.tgz cov-int
 " > ${GITHUB_WORKSPACE}/coverity_scan.sh
 chmod a+x ${GITHUB_WORKSPACE}/coverity_scan.sh
 
+echo "::endgroup::" # Launch container
+
 echo "#####################################################################"
 echo "###################### Executing Coverity Scan ######################"
 echo "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
@@ -96,6 +99,7 @@ echo "#####################################################################"
 echo "###################### Coverity Scan Compelte #######################"
 echo "#####################################################################"
 
+echo "::group::Upload artifacts"
 echo "Start uploading compilation units for analysis"
 
 docker cp view_worker:/myproject.tgz myproject.tgz
@@ -110,3 +114,4 @@ if [ "$1" != "local" ]; then
 else
   echo "Not submitting to server only test run"
 fi
+echo "::endgroup::"

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+echo "::group::Launching container"
 
 echo "Checking if there is a working CVMFS mount"
 
@@ -61,6 +62,7 @@ else
   echo "Docker image ready for ${SYSTEM}"
 fi
 
+echo "::endgroup::" # Launch container
 
 echo "####################################################################"
 echo "###################### Executing user payload ######################"

--- a/run-macOS.sh
+++ b/run-macOS.sh
@@ -1,6 +1,9 @@
 #!/bin/zsh
 
 set -e
+
+echo "::group::Launching container"
+
 if [ -z "${VIEW_PATH}" ]; then
   echo "Checking if there is a working CVMFS mount"
 
@@ -51,6 +54,8 @@ cd ${GITHUB_WORKSPACE}
 ${RUN}
 " > ${GITHUB_WORKSPACE}/action_payload.sh
 chmod a+x ${GITHUB_WORKSPACE}/action_payload.sh
+
+echo "::endgroup::" # Launch container
 
 echo "####################################################################"
 echo "###################### Executing user payload ######################"


### PR DESCRIPTION
Using the `::group::` syntax suggested in https://github.com/AIDASoft/run-lcg-view/issues/1#issuecomment-1061805986 to collapse the setup steps in the output logs.

For further grouping it is still necessary to introduce similar groups in the workflows that use the action.