### PR TITLE
Add ccache to linux workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,10 +56,23 @@ inputs:
     description: 'Custom path where the setup script for the view is location'
     required: false
     default: ''
+  ccache-key:
+    description: 'Base key for ccache '
+    required: false
+    default: 'ccache'
 
 runs:
   using: "composite"
   steps:
+    - shell: bash
+      run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ${{ inputs.ccache-key }}-${{ env.NOW }}
+        restore-keys: |
+          ${{ inputs.ccache-key }}
+
     - name: Run payload
       shell: bash
       run: |

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -45,12 +45,22 @@ set -e
 
 source ${VIEW_PATH}/${SETUP_SCRIPT}
 
+export CCACHE_DIR=/root/.cache/ccache
+export CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime
+ccache --set-config=max_size=500M
+ccache -z
+
 ${RUN}
+
+echo ::group::ccache statistics
+ccache -s
+echo ::endgroup::
 " > ${GITHUB_WORKSPACE}/action_payload.sh
+
 chmod a+x ${GITHUB_WORKSPACE}/action_payload.sh
 
 echo "Starting docker image for ${SYSTEM}"
-docker run -it --name view_worker -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/${SYSTEM}:latest /bin/bash
+docker run -it --name view_worker -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -v /cvmfs:/cvmfs:shared -v ~/.cache/ccache:/root/.cache/ccache -d ghcr.io/aidasoft/${SYSTEM}:latest /bin/bash
 echo "Docker image ready for ${SYSTEM}"
 echo "::endgroup::" # Launch container
 


### PR DESCRIPTION
Add a basic ccache setup to the linux based workflow. This includes the caching via `actions/cache` as well as some environment setup. **Users still have to opt-in to actually use `ccache`**, e.g. via `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache`.

Some of the images are currently missing `ccache`, see https://github.com/AIDASoft/management/pull/9