### PR TITLE
Remove option to run from unpacked.cern.ch and update CI workflows

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -10,7 +10,7 @@ jobs:
       with:
         run_local_checkout: 'true'
         unpacked: 'true'
-        release-platform: "LCG_99/x86_64-centos7-gcc10-opt"
+        release-platform: "LCG_100/x86_64-centos8-gcc10-opt"
         run: |
           gcc --version
           which gcc

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,19 +1,6 @@
 name: linux
 on: [push, pull_request]
 jobs:
-  singularity:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
-    - uses: aidasoft/run-lcg-view@main
-      with:
-        run_local_checkout: 'true'
-        unpacked: 'true'
-        release-platform: "LCG_100/x86_64-centos8-gcc10-opt"
-        run: |
-          gcc --version
-          which gcc
   docker:
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +9,6 @@ jobs:
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'
-        unpacked: 'false'
         release-platform: "LCG_99/x86_64-centos7-gcc10-opt"
         run: |
           gcc --version

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -4,8 +4,8 @@ jobs:
   singularity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'
@@ -17,8 +17,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,8 +4,8 @@ jobs:
   run-coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'
-        release-platform: "dev3/x86_64-centos7-gcc10-opt"
+        release-platform: "dev3/x86_64-el9-gcc13-opt"
         run: |
           gcc --version
           which gcc

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,8 +4,8 @@ jobs:
   run-lcg:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'

--- a/.github/workflows/ilcsoft.yml
+++ b/.github/workflows/ilcsoft.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'
-        view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/100/nightly/x86_64-centos7-gcc10-opt"
+        view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/104/nightly/x86_64-centos7-gcc11-opt"
         setup-script: "init_ilcsoft.sh"
         run: |
           which ddsim

--- a/.github/workflows/ilcsoft.yml
+++ b/.github/workflows/ilcsoft.yml
@@ -4,8 +4,8 @@ jobs:
   run-lcg:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'
-        container: "centos7"
+        container: "el9"
         view-path: "/cvmfs/sw.hsf.org/key4hep"
         run: |
           which ddsim

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -4,8 +4,8 @@ jobs:
   run-lcg:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@main
       with:
         run_local_checkout: 'true'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The following parameters are supported:
  - `platform`: LCG view platform you are targeting (e.g. `x86_64-centos8-gcc10-opt`)
  - `release`: LCG view release you are targeting (e.g. `LCG_99`)
  - `release-platform`:LCG view release platform string you are targeting (e.g. `LCG_99/x86_64-centos8-gcc10-opt`)
- - `unpacked`: Use image from `/cvmfs/unpacked.cern.ch` with Singularity, or if `false` use GitHub Container Registry with Docker (default: `false`)
  - `run`: They payload code you want to execute on top of the view
  - `setup-script`: Initialization/Setup script for a view that sets the environment (e.g. `setup.sh`)
  - `view-path`: Path where the setup script for the custom view is location. By specifying this variable the auto-resolving of the view based on `release` and `platform` is disabled. Furthermore the full path has to contain the architecture of the build in the form `/dir1/dir2/x86_64-{arch}-gcc../dir4/dir5`. The system will try to resolve the docker container equal to the string `{arch}` (the string after `x86_64-`).

--- a/action.yml
+++ b/action.yml
@@ -40,10 +40,6 @@ inputs:
     description: 'LCG view release platform string you are targeting (e.g. LCG_99/x86_64-centos8-gcc10-opt'
     required: false
     default: ''
-  unpacked:
-    description: 'Use image from /cvmfs/unpacked.cern.ch with Singularity, or if false use GitHub Container Registry with Docker'
-    required: false
-    default: 'false'
   run:
     description: 'They payload code you want to execute on top of the view'
     required: false
@@ -85,7 +81,6 @@ runs:
         LCG_RELEASE: ${{ inputs.release }}
         LCG_RELEASE_PLATFORM: ${{ inputs.release-platform }}
         LCG_PLATFORM: ${{ inputs.platform }}
-        UNPACKED: ${{ inputs.unpacked }}
         RUN: ${{ inputs.run }}
         SETUP_SCRIPT: ${{ inputs.setup-script }}
         VIEW_PATH: ${{ inputs.view-path }}

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -49,27 +49,13 @@ ${RUN}
 " > ${GITHUB_WORKSPACE}/action_payload.sh
 chmod a+x ${GITHUB_WORKSPACE}/action_payload.sh
 
-if [ ${UNPACKED} == "true" ]; then
-  echo "Install Singularity"
-  conda install --quiet --yes -c conda-forge singularity > /dev/null 2>&1
-  eval "$(conda shell.bash hook)"
-
-  echo "Starting Singularity image for ${SYSTEM} from /cvmfs/unpacked.cern.ch"
-  singularity instance start --bind /cvmfs --bind ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} /cvmfs/unpacked.cern.ch/ghcr.io/aidasoft/${SYSTEM}:latest view_worker
-else
-  echo "Starting docker image for ${SYSTEM}"
-  docker run -it --name view_worker -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/${SYSTEM}:latest /bin/bash
-  echo "Docker image ready for ${SYSTEM}"
-fi
-
+echo "Starting docker image for ${SYSTEM}"
+docker run -it --name view_worker -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/${SYSTEM}:latest /bin/bash
+echo "Docker image ready for ${SYSTEM}"
 echo "::endgroup::" # Launch container
 
 echo "####################################################################"
 echo "###################### Executing user payload ######################"
 echo "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
 
-if [ ${UNPACKED} == "true" ]; then
-  singularity exec instance://view_worker /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"
-else
-  docker exec view_worker /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"
-fi
+docker exec view_worker /bin/bash -c "cd ${GITHUB_WORKSPACE}; ./action_payload.sh"


### PR DESCRIPTION
Switch to latest versions of actions that we use and also switch to existing builds and more future proof releases for tests.