### PR TITLE
Make it possible to switch to podman as container runtime for linux

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,12 @@ inputs:
     description: 'Base key for ccache '
     required: false
     default: 'ccache'
+  container-runtime:
+    description: 'Container runtime to use to launch container (only for linux)'
+    required: false
+    type: choice
+    options: ['docker', 'podman']
+    default: 'docker'
 
 runs:
   using: "composite"
@@ -97,3 +103,4 @@ runs:
         RUN: ${{ inputs.run }}
         SETUP_SCRIPT: ${{ inputs.setup-script }}
         VIEW_PATH: ${{ inputs.view-path }}
+        CONTAINER_RUNTIME: ${{ inputs.container-runtime }}

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -59,6 +59,8 @@ echo ::endgroup::
 
 chmod a+x ${GITHUB_WORKSPACE}/action_payload.sh
 
+mkdir -p ${HOME}/.cache/ccache
+
 declare -A container_args=(
   [podman]="-d -i"
   [docker]="-it -d"

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -81,4 +81,4 @@ echo "####################################################################"
 echo "###################### Executing user payload ######################"
 echo "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV"
 
-${CONTAINER_RUNTIME} exec -it view_worker /bin/bash -c "cd ${GITHUB_WORKSPACE} && ./action_payload.sh"
+${CONTAINER_RUNTIME} exec view_worker /bin/bash -c "cd ${GITHUB_WORKSPACE} && ./action_payload.sh"


### PR DESCRIPTION
Triggered by https://its.cern.ch/jira/browse/SPI-2838

This makes it possible to switch to `podman` for the container runtime. Docker remains the default