### PR TITLE
fix: direct users to most recent cvmfs-contrib/github-action-cvmfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This GitHub Action executes user payload code inside a LCG view environment, spe
 ## Instructions
 
 ### Prerequisites
-This action depends on the user to call the companion action `uses: cvmfs-contrib/github-action-cvmfs@v2` before using `uses: aidasoft/run-lcg-view@v4`, which will install CVMFS on the node. GitHub Actions currently do not support calling the action `github-action-cvmfs` from within `run-lcg-view`, this needs to be done explicitly by the user.
+This action depends on the user to call the companion action `uses: cvmfs-contrib/github-action-cvmfs@v2` (or a more recent version) before using `uses: aidasoft/run-lcg-view@v4`, which will install CVMFS on the node. GitHub Actions currently do not support calling the action `github-action-cvmfs` from within `run-lcg-view`, this needs to be done explicitly by the user.
 
 ### Example
 

--- a/run-coverity.sh
+++ b/run-coverity.sh
@@ -7,19 +7,19 @@ echo "Checking if there is a working CVMFS mount"
 
 if [ ! -d "/cvmfs/sft.cern.ch/lcg/" ]; then
   echo "The directory /cvmfs/sft.cern.ch/lcg/ cannot be accessed!"
-  echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+  echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
   exit 1
 fi
 
 if [ ! -d "/cvmfs/sft-nightlies.cern.ch/lcg/" ]; then
   echo "The directory /cvmfs/sft-nightlies.cern.ch/lcg/ cannot be accessed!"
-  echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+  echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
   exit 1
 fi
 
 if [ ! -d "/cvmfs/geant4.cern.ch/share/" ]; then
   echo "The directory /cvmfs/geant4.cern.ch/share/ cannot be accessed!"
-  echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+  echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
   exit 1
 fi
 

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -7,19 +7,19 @@ echo "Checking if there is a working CVMFS mount"
 
 if [ ! -d "/cvmfs/sft.cern.ch/lcg/" ]; then
   echo "The directory /cvmfs/sft.cern.ch/lcg/ cannot be accessed!"
-  echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+  echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
   exit 1
 fi
 
 if [ ! -d "/cvmfs/sft-nightlies.cern.ch/lcg/" ]; then
   echo "The directory /cvmfs/sft-nightlies.cern.ch/lcg/ cannot be accessed!"
-  echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+  echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
   exit 1
 fi
 
 if [ ! -d "/cvmfs/geant4.cern.ch/share/" ]; then
   echo "The directory /cvmfs/geant4.cern.ch/share/ cannot be accessed!"
-  echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+  echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
   exit 1
 fi
 

--- a/run-macOS.sh
+++ b/run-macOS.sh
@@ -9,7 +9,7 @@ if [ -z "${VIEW_PATH}" ]; then
 
   if [ ! -d "/Users/Shared/cvmfs/sft.cern.ch/lcg/" ]; then
     echo "The directory /Users/Shared/cvmfs/sft.cern.ch/lcg cannot be accessed!"
-    echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+    echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
     echo "and that you have set cvmfs_repositories: 'sft.cern.ch,geant4.cern.ch'."
     echo "There is no automout on macOS."
     exit 1
@@ -17,7 +17,7 @@ if [ -z "${VIEW_PATH}" ]; then
 
   if [ ! -d "/Users/Shared/cvmfs/geant4.cern.ch/share/" ]; then
     echo "The directory /Users/Shared/cvmfs/geant4.cern.ch/share/ cannot be accessed!"
-    echo "Make sure you are using the cvmfs-contrib/github-action-cvmfs@v2 action"
+    echo "Make sure you are using the most recent cvmfs-contrib/github-action-cvmfs version"
     echo "and that you have set cvmfs_repositories: 'sft.cern.ch,geant4.cern.ch'."
     echo "There is no automout on macOS."
     exit 1


### PR DESCRIPTION
This PR fixes some warnings and documentation that may direct the user to an old version of cvmfs-contrib/github-action-cvmfs.